### PR TITLE
Apply workaround of Emacs bug#18845

### DIFF
--- a/systemtap-mode.el
+++ b/systemtap-mode.el
@@ -55,6 +55,11 @@
   (require 'cc-langs)
   (require 'cc-fonts))
 
+;; Work around emacs bug#18845
+(eval-and-compile
+  (when (and (= emacs-major-version 24) (>= emacs-minor-version 4))
+    (require 'cl)))
+
 (eval-and-compile
   (c-add-language 'systemtap-mode 'awk-mode))
 


### PR DESCRIPTION
If users use Emacs 24.4 or 24.5, they cannot load this package by Emacs bug#18845. Then they get following error message. This change is workaround of this bug.

```
Eval error in the `c-lang-defconst' for `c-regular-keywords-regexp' in systemtap-mode:
Eval error in the `c-lang-defconst' for `c-basic-matchers-before' in systemtap-mode:
Eval error in the `c-lang-defconst' for `c-matchers-2' in systemtap-mode:
Load error for /home/syohei/systemtap-mode/systemtap-mode.el:
(void-function set-difference)
```

See Also
- https://lists.gnu.org/archive/html/bug-gnu-emacs/2014-10/msg01175.html
